### PR TITLE
Separate lottery/deposit logic from NFT + VRF

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/foundry-chainlink-toolkit"]
+	path = lib/foundry-chainlink-toolkit
+	url = https://github.com/smartcontractkit/foundry-chainlink-toolkit

--- a/src/NFTLotteryTicket.sol
+++ b/src/NFTLotteryTicket.sol
@@ -1,192 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
-import "./interfaces/IDeposit.sol";
-import "./vendor/GelatoVRFConsumerBase.sol";
+import { ERC1155 } from "../lib/openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol";
+import { Ownable } from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
-contract NFTLotteryTicket is ERC1155, GelatoVRFConsumerBase {
-    uint256 public constant TOKEN_ID = 1;
+contract NFTLotteryTicket is ERC1155, Ownable(msg.sender) {
+    constructor(string memory uri) ERC1155(uri) {}
 
-    address public seller;
-    IDeposit public depositContract;
-    IDeposit.LotteryState public lotteryState;
-    uint256 public minimumDepositAmount;
+    uint256 public nextTokenId = 1;
+    address public depositContractAddr;
 
-    // Needed for GelatoVRFConsumerBase
-    address private _operatorAddr;
-
-    // TODO: Do we actually need to clear this array?
-    // If yes, then we need to add a function to clear this array
-    // after the lottery is ended
-    // If we do 'fire n forget' minting, then we don't need to clear this array
-    // and provide a good UX/UI that sellers need to redeploy
-    // which will make this a template contract so to speak
-    address[] private eligibleParticipants;
-    uint256 public numberOfTickets;
-    mapping(address => bool) public hasMinted;
-
-    event LotteryStarted();
-    event WinnerSelected(address indexed winner);
-    event LotteryEnded();
-
-    constructor(string memory uri) ERC1155(uri) {
-        seller = msg.sender;
+    function setDepositContractAddr(address _depositContractAddr) public onlyOwner {
+        depositContractAddr = _depositContractAddr;
     }
 
-    modifier onlySeller() {
-        require(msg.sender == seller, "Only seller can call this function");
-        _;
-    }
+    function lotteryMint(address winner) public {
+        require(msg.sender == depositContractAddr, "Only deposit contract can mint");
 
-    modifier lotteryNotStarted() {
-        require(lotteryState == IDeposit.LotteryState.NOT_STARTED, "Lottery is in active state");
-        _;
-    }
-
-    modifier lotteryStarted() {
-        require(lotteryState == IDeposit.LotteryState.ACTIVE, "Lottery is not active");
-        _;
-    }
-
-    modifier lotteryEnded() {
-        require(lotteryState == IDeposit.LotteryState.ENDED, "Lottery is not ended yet");
-        _;
-    }
-
-    modifier isWinner() {
-        require(depositContract.isWinner(msg.sender), "Caller is not a winner");
-        _;
-    }
-
-    modifier hasNotMinted() {
-        require(!hasMinted[msg.sender], "NFT already minted");
-        _;
-    }
-
-    modifier validTokenId(uint256 _tokenId) {
-        require(_tokenId == TOKEN_ID, "Invalid token ID");
-        _;
-    }
-
-    function setOperatorAddress(address operator) public onlySeller {
-        require(operator != address(0), "Invalid operator address");
-        _operatorAddr = operator;
-    }
-
-    // Private function for random number generation
-    // TODO: Replace with VRF logic and callback based
-
-    function _operator() internal view virtual override returns (address) {
-        return _operatorAddr;
-    }
-
-    function _fulfillRandomness(uint256 randomness, uint256, bytes memory extraData) internal override {
-        require(lotteryState == IDeposit.LotteryState.ACTIVE, "Lottery is not active");
-        require(numberOfTickets > 0, "No tickets left to allocate");
-
-        address sellerAddress = abi.decode(extraData, (address));
-
-        // You can now use sellerAddress for verification or tracking
-        require(sellerAddress == msg.sender, "Only the original seller can fulfill randomness");
-
-        uint256 randomIndex = randomness % eligibleParticipants.length;
-        address selectedWinner = eligibleParticipants[randomIndex];
-
-        if (!depositContract.isWinner(selectedWinner)) {
-            depositContract.setWinner(selectedWinner);
-            removeParticipant(randomIndex);
-            numberOfTickets--;
-
-            // Emit an event each time a winner is selected
-            emit WinnerSelected(selectedWinner);
-
-            // If there are still tickets left, you can request more randomness for the next winner
-            if (numberOfTickets == 0) {
-                emit LotteryEnded();
-            }
-        }
-    }
-
-    function initiateSelectWinner() public onlySeller lotteryStarted {
-        require(numberOfTickets > 0, "All tickets have been allocated");
-        require(eligibleParticipants.length > 0, "No eligible participants left");
-
-        // Use the seller's address as extraData
-        bytes memory extraData = abi.encode(msg.sender);
-
-        // Request randomness from Gelato's VRF with the seller's address as extraData
-        _requestRandomness(extraData);
-
-        // Optionally, you can emit an event here if you want to signal that the selection process has started
-        // emit LotterySelectionInitiated();
-    }
-
-    function setMinimumDepositAmount(uint256 _amount) public onlySeller {
-        minimumDepositAmount = _amount;
-    }
-
-    function setNumberOfTickets(uint256 _numberOfTickets) public onlySeller {
-        require(_numberOfTickets > 0, "Number of tickets must be greater than zero");
-        numberOfTickets = _numberOfTickets;
-    }
-
-    function setDepositContract(address _depositContractAddress) public onlySeller {
-        depositContract = IDeposit(_depositContractAddress);
-    }
-
-    function startLottery() public onlySeller lotteryNotStarted {
-        lotteryState = IDeposit.LotteryState.ACTIVE;
-        depositContract.changeLotteryState(IDeposit.LotteryState.ACTIVE);
-        // Additional logic for starting the lottery
-        // Check eligible participants, etc.
-        checkEligibleParticipants();
-    }
-
-    function endLottery() public onlySeller lotteryStarted {
-        lotteryState = IDeposit.LotteryState.ENDED;
-        depositContract.changeLotteryState(IDeposit.LotteryState.ENDED);
-        // Additional logic for ending the lottery
-        // Process winners, mint NFT tickets, etc.
-    }
-
-    // Function to check and mark eligible participants
-    function checkEligibleParticipants() internal {
-        address[] memory participants = depositContract.getParticipants();
-        for (uint256 i = 0; i < participants.length; i++) {
-            uint256 depositedAmount = depositContract.getDepositedAmount(participants[i]);
-            if (depositedAmount >= minimumDepositAmount) {
-                // Mark this participant as eligible for the lottery
-                eligibleParticipants.push(participants[i]);
-            }
-        }
-    }
-
-    function removeParticipant(uint256 index) internal {
-        require(index < eligibleParticipants.length, "Index out of bounds");
-
-        // If the winner is not the last element, swap it with the last element
-        if (index < eligibleParticipants.length - 1) {
-            eligibleParticipants[index] = eligibleParticipants[eligibleParticipants.length - 1];
-        }
-
-        // Remove the last element (now the winner)
-        eligibleParticipants.pop();
-    }
-
-    function isParticipantEligible(address participant) public view returns (bool) {
-        for (uint256 i = 0; i < eligibleParticipants.length; i++) {
-            if (eligibleParticipants[i] == participant) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function mintMyNFT(uint256 tokenId) public lotteryEnded isWinner hasNotMinted validTokenId(tokenId) {
-        require(eligibleParticipants.length > 0, "No eligible participants");
-
-        _mint(msg.sender, tokenId, 1, ""); // Mint 1 NFT to the winner
-        hasMinted[msg.sender] = true; // Mark that the winner has minted their NFT
+        _mint(winner, nextTokenId, 1, ""); // Mint 1 NFT to the winner
+        nextTokenId++;
     }
 }

--- a/src/interfaces/INFTLotteryTicket.sol
+++ b/src/interfaces/INFTLotteryTicket.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+interface INFTLotteryTicket {
+  function lotteryMint(address winner) external;
+}

--- a/test/NFTLotteryTicket.t.sol
+++ b/test/NFTLotteryTicket.t.sol
@@ -3,83 +3,75 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/NFTLotteryTicket.sol";
-import "./MockDeposit.sol";
+import "../src/Deposit.sol";
+import { VRFCoordinatorV2Mock } from "@chainlink/contracts/v0.8/mocks/VRFCoordinatorV2Mock.sol";
 
 contract NFTLotteryTicketTest is Test {
     NFTLotteryTicket private nftLotteryTicket;
-    MockDeposit private mockDeposit;
+    VRFCoordinatorV2Mock public vrfMock;
+    Deposit private deposit;
+    
+    uint256 private sellerPrivateKey = 0xa11ce;
+    uint256 private multisigWalletPrivateKey = 0xb334d;
+    address seller;
 
     function setUp() public {
-        // Deploy the MockDeposit and NFTLotteryTicket contracts
-        mockDeposit = new MockDeposit();
+        seller = vm.addr(sellerPrivateKey);
+        
+        vrfMock = new VRFCoordinatorV2Mock(0, 0);
+        vm.startPrank(seller);
+        uint64 subId = vrfMock.createSubscription();
+        vrfMock.fundSubscription(subId, 1000000000000000000000);
+        vm.stopPrank();
+
+        deposit = new Deposit(seller, subId, address(vrfMock));
         nftLotteryTicket = new NFTLotteryTicket("ipfs://example_uri/");
-
-        // Set the MockDeposit contract address in NFTLotteryTicket
-        nftLotteryTicket.setDepositContract(address(mockDeposit));
+        nftLotteryTicket.setDepositContractAddr(address(deposit));
+        deposit.setNftContractAddr(address(nftLotteryTicket));
     }
 
-    function testInitialLotteryState() public {
-        // Verify that the lottery state is initially NOT_STARTED
-        assertEq(uint256(nftLotteryTicket.lotteryState()), uint256(IDeposit.LotteryState.NOT_STARTED));
-    }
-
-    function testStartLottery() public {
-        // Start the lottery
-        nftLotteryTicket.startLottery();
-
-        // Verify that the lottery state has changed to ACTIVE
-        assertEq(uint256(nftLotteryTicket.lotteryState()), uint256(IDeposit.LotteryState.ACTIVE));
-    }
-
-    function testEligibilityCheck() public {
-        // Simulate deposit amounts in MockDeposit
-        address participant1 = address(1);
-        address participant2 = address(2);
-        uint256 eligibleAmount = 100; // Assume 100 is the minimum deposit amount for eligibility
-        nftLotteryTicket.setMinimumDepositAmount(eligibleAmount);
-        mockDeposit.setDepositedAmount(participant1, eligibleAmount);
-        mockDeposit.setDepositedAmount(participant2, eligibleAmount / 2); // Ineligible amount
-
-        // Start the lottery, which should also check eligibility
-        nftLotteryTicket.startLottery();
-
-        // Check if participant1 is marked eligible
-        bool isParticipant1Eligible = nftLotteryTicket.isParticipantEligible(participant1);
-        assertTrue(isParticipant1Eligible);
-
-        // Check if participant2 is not marked eligible
-        bool isParticipant2Eligible = nftLotteryTicket.isParticipantEligible(participant2);
-        assertFalse(isParticipant2Eligible);
-    }
-
-    function testEndLottery() public {
-        // Setup: Start the lottery first
-        nftLotteryTicket.startLottery();
-
-        // End the lottery
-        nftLotteryTicket.endLottery();
-
-        // Verify that the lottery state has changed to ENDED
-        assertEq(uint256(nftLotteryTicket.lotteryState()), uint256(IDeposit.LotteryState.ENDED));
-    }
-
-    function testInvalidActions() public {
-        // Attempt to start the lottery when it's already active
-        nftLotteryTicket.startLottery();
-        vm.expectRevert("Lottery is in active state");
-        nftLotteryTicket.startLottery();
-
-        nftLotteryTicket.endLottery();
-        // Attempt to end the lottery when it's not started
-        vm.expectRevert("Lottery is not active");
-        nftLotteryTicket.endLottery();
-
-        // Attempt to mint NFT as a non-winner
-        address nonWinner = address(2); // Assuming address(2) is not a winner
+    function test_NonWinnerCannotMint() public {
+        address nonWinner = address(1);
         vm.prank(nonWinner);
-        vm.expectRevert("Caller is not a winner");
-        nftLotteryTicket.mintMyNFT(1);
+        vm.expectRevert("Only deposit contract can mint");
+        nftLotteryTicket.lotteryMint(nonWinner);
+        vm.stopPrank();
     }
 
-    // Additional test cases can be added here
+    function testWinnersCanMint() public {
+        address joeWinner = address(1);
+        address annaWinner = address(2);
+
+        vm.startPrank(seller);
+        deposit.startLottery();
+        deposit.setWinner(joeWinner);
+        deposit.setWinner(annaWinner);
+        deposit.endLottery();
+        vm.stopPrank();
+
+        vm.prank(joeWinner);
+        deposit.mintMyNFT();
+        assertEq(nftLotteryTicket.balanceOf(joeWinner, 1), 1, "Joe must own NFT#1");
+
+        vm.prank(annaWinner);
+        deposit.mintMyNFT();
+        assertEq(nftLotteryTicket.balanceOf(annaWinner, 2), 1, "Anna must own NFT#2");
+    }    
+
+    function testWinnersCannotMintTwice() public {
+        address joeWinner = address(1);
+
+        vm.startPrank(seller);
+        deposit.startLottery();
+        deposit.setWinner(joeWinner);
+        deposit.endLottery();
+        vm.stopPrank();
+
+        vm.startPrank(joeWinner);
+        deposit.mintMyNFT();
+        assertEq(nftLotteryTicket.balanceOf(joeWinner, 1), 1, "Joe must own NFT#1");
+        vm.expectRevert("NFT already minted");
+        deposit.mintMyNFT();
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
What is scope of this PR? 

1. Make NFT contract lightweight 
2. Have a single contract for lottery and deposits 
3. Integrate Chainlink VRF for random winner selection (Gelato wasn't working to me) 

Sample Deposits contract: 
https://sepolia.etherscan.io/address/0xb1edddd6ac909b482339041ba570ddb814c6176d

Sample NFT contract: 
https://sepolia.etherscan.io/token/0x100d224bb86430aed65ca357b18a9a55ec833bd3